### PR TITLE
Added code validation and valid bit to letter import

### DIFF
--- a/app/Grimm/Import/Records/LetterRecord.php
+++ b/app/Grimm/Import/Records/LetterRecord.php
@@ -1,0 +1,104 @@
+<?php
+
+
+namespace Grimm\Import\Records;
+
+
+class LetterRecord implements Record {
+
+    /**
+     * The id of the letter
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * The code of the letter, which is stored as a big decimal
+     * @var string
+     */
+    protected $code;
+
+    /**
+     * The two character language code of the letter
+     * @var string
+     */
+    protected $language;
+
+    /**
+     * Human readable date of the letter
+     * @var string
+     */
+    protected $date;
+
+    /**
+     * The associated information of a letter
+     * TODO: Might be good to extract this into own object
+     * @var array
+     */
+    protected $information;
+
+    function __construct($id, $code, $language, $date, $information)
+    {
+        $this->id = $id;
+        $this->code = trim($code);
+        $this->language = $language;
+        $this->date = $date;
+        $this->information = $information;
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'id'            => $this->getId(),
+            'code'          => $this->getCode(),
+            'language'      => $this->getLanguage(),
+            'date'          => $this->getDate(),
+            'information'   => $this->getInformation()
+        ];
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLanguage()
+    {
+        return $this->language;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * @return array
+     */
+    public function getInformation()
+    {
+        return $this->information;
+    }
+}

--- a/app/Grimm/Import/Records/Record.php
+++ b/app/Grimm/Import/Records/Record.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Grimm\Import\Records;
+
+
+use Illuminate\Support\Contracts\ArrayableInterface;
+
+interface Record extends ArrayableInterface {
+
+}

--- a/app/Grimm/Import/Validation/LetterValidation.php
+++ b/app/Grimm/Import/Validation/LetterValidation.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Grimm\Import\Validation;
+
+
+use Grimm\Import\Records\Record;
+
+class LetterValidation implements RecordValidation {
+
+    public function validate($record)
+    {
+        $codeRegexp = '/^[0-9]{8}(\.[0-9]{1,2})?$/';
+
+        return !!preg_match($codeRegexp, $record->getCode());
+    }
+}

--- a/app/Grimm/Import/Validation/RecordValidation.php
+++ b/app/Grimm/Import/Validation/RecordValidation.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace Grimm\Import\Validation;
+
+
+use Grimm\Import\Records\Record;
+
+interface RecordValidation {
+    /**
+     * Validates the given record, returning true if valid, false otherwise!
+     * @param $record
+     * @return bool
+     */
+    public function validate($record);
+}

--- a/app/Grimm/Search/EloquentSearchService.php
+++ b/app/Grimm/Search/EloquentSearchService.php
@@ -117,7 +117,7 @@ class EloquentSearchService implements SearchService {
      */
     public function getDateRange()
     {
-        $range = $this->letter->selectRaw('MIN(code) as min, MAX(code) as max')->first();
+        $range = $this->letter->selectRaw('MIN(code) as min, MAX(code) as max')->where('valid', 1)->first();
 
         $min = Carbon::createFromFormat("Ymd", substr($range->min, 0, -3));
         $max = Carbon::createFromFormat("Ymd", substr($range->max, 0, -3));

--- a/app/database/migrations/2015_03_06_145419_add_invalid_bit_to_letters.php
+++ b/app/database/migrations/2015_03_06_145419_add_invalid_bit_to_letters.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddInvalidBitToLetters extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('letters', function(Blueprint $table)
+		{
+			$table->tinyInteger('valid')->default(1);
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('letters', function(Blueprint $table)
+		{
+			$table->dropColumn('valid');
+		});
+	}
+
+}

--- a/app/tests/LetterValidationTest.php
+++ b/app/tests/LetterValidationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+
+use Grimm\Import\Records\LetterRecord;
+use Grimm\Import\Validation\LetterValidation;
+
+class LetterValidationTest extends TestCase {
+
+    /**
+     * @var LetterValidation
+     */
+    protected $letterValidation;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->letterValidation = new LetterValidation();
+    }
+
+
+    public function testRejectInvalidCode()
+    {
+        $letter1 = new LetterRecord(6879, '1830.00', '', '15. Juli 1830', []);
+        $letter2 = new LetterRecord(13420, '1851132.00', 'sw', 'November 1851', []);
+        $letter3 = new LetterRecord(8535, '183701180.00', '', '18. Januar 1837', []);
+        $letter4 = new LetterRecord(16230, '18630814.000', '', '14. August 1863', []);
+        $letter5 = new LetterRecord(16230, '1863081400', '', '14. August 1863', []);
+
+        $this->assertFalse($this->letterValidation->validate($letter1));
+        $this->assertFalse($this->letterValidation->validate($letter2));
+        $this->assertFalse($this->letterValidation->validate($letter3));
+        $this->assertFalse($this->letterValidation->validate($letter4));
+        $this->assertFalse($this->letterValidation->validate($letter5));
+    }
+
+    public function testAcceptValidCode()
+    {
+        $letter1 = new LetterRecord(16230, '18630814.00', '', '14. August 1863', []);
+        $letter2 = new LetterRecord(16230, '18630814.01', '', '14. August 1863', []);
+        $letter3 = new LetterRecord(16230, '18700000.00', '', '14. August 1863', []);
+        $letter4 = new LetterRecord(16230, '18700000', '', '14. August 1863', []);
+
+        $this->assertTrue($this->letterValidation->validate($letter1));
+        $this->assertTrue($this->letterValidation->validate($letter2));
+        $this->assertTrue($this->letterValidation->validate($letter3));
+        $this->assertTrue($this->letterValidation->validate($letter4));
+    }
+
+    public function testTest()
+    {
+        $code = '18511236.11';
+        $newCode = preg_replace('/^([0-9]{8}\.1)0([0-9])$/', '$1$2', $code);
+        var_dump($newCode);
+    }
+
+
+}

--- a/app/views/pages/search.blade.php
+++ b/app/views/pages/search.blade.php
@@ -70,7 +70,7 @@
                             <div class="form-group" ng-class="{'has-error': !quicksearchForm.quicksearchCode.$valid}">
                                 <label class="col-md-2 control-label" for="letter_code">Letter Code:</label>
                                 <div class="control-group col-md-10">
-                                    <input type="text" class="form-control" name="quicksearchCode" ng-model="quicksearch.code" ng-pattern="/[0-9]{8}\.[0-9]{2}/" />
+                                    <input type="text" class="form-control" name="quicksearchCode" ng-model="quicksearch.code" ng-pattern="/^[0-9]{8}\.[0-9]{2}$/" />
                                     <span class="help-block" ng-show="!quicksearchForm.quicksearchCode.$valid">Invalid format of the given letter code!</span>
                                     <span class="help-block">Access a letter directly by its code which has the form <code>yyyymmdd.nn</code> where y are the digits of the year, m the month, d the day and n the order count.</span>
                                 </div>


### PR DESCRIPTION
This marks letters with an invalid letter code and thus can exclude it
from the date range request for example.
Note that this is not as strict as the pattern demanded by the GUI as
there are many values in the dbf file that have no decimal places.
It also tries to correct decimal places in the form of .101 to .11 to
accommodate the new code structure.
